### PR TITLE
css-mediaquery => css-mq-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/twbs/mq4-hover-shim",
   "dependencies": {
-    "css-mediaquery": "^0.1.2",
+    "css-mq-parser": "^0.0.2",
     "postcss": "^4.0.0"
   },
   "devDependencies": {

--- a/src/nodejs/postprocessor.js
+++ b/src/nodejs/postprocessor.js
@@ -9,12 +9,12 @@
 'use strict';
 
 var postcss = require('postcss');
-var mediaQuery = require('css-mediaquery');
+var parseMediaQuery = require('css-mq-parser');
 
 
 // Returns media type iff the at-rule is: @media optional-media-type (hover: hover) {...}
 function mediaTypeIfSimpleHoverHover(atRule) {
-    var mediaOrs = mediaQuery.parse(atRule.params);
+    var mediaOrs = parseMediaQuery(atRule.params);
     if (mediaOrs.length !== 1) {
         return false;
     }

--- a/test/postprocessor_test.js
+++ b/test/postprocessor_test.js
@@ -56,8 +56,8 @@ exports.mq4HoverShim = {
             "@media (hover: hover), (orientation: landscape) { .foobar { display: none; } }"
         );
         test.deepEqual(
-            postprocessor({hoverSelectorPrefix: 'PREFIX>'}).process("@media screen (hover: hover), (orientation: landscape) { .foobar { display: none; } }").css,
-            "@media screen (hover: hover), (orientation: landscape) { .foobar { display: none; } }"
+            postprocessor({hoverSelectorPrefix: 'PREFIX>'}).process("@media screen and (hover: hover), screen and (orientation: landscape) { .foobar { display: none; } }").css,
+            "@media screen and (hover: hover), screen and (orientation: landscape) { .foobar { display: none; } }"
         );
         test.done();
     },
@@ -68,8 +68,8 @@ exports.mq4HoverShim = {
             "@media (hover: hover) and (orientation: landscape) { .foobar { display: none; } }"
         );
         test.deepEqual(
-            postprocessor({hoverSelectorPrefix: 'PREFIX>'}).process("@media screen (hover: hover) and (orientation: landscape) { .foobar { display: none; } }").css,
-            "@media screen (hover: hover) and (orientation: landscape) { .foobar { display: none; } }"
+            postprocessor({hoverSelectorPrefix: 'PREFIX>'}).process("@media screen and (hover: hover) and (orientation: landscape) { .foobar { display: none; } }").css,
+            "@media screen and (hover: hover) and (orientation: landscape) { .foobar { display: none; } }"
         );
         test.done();
     },
@@ -108,23 +108,23 @@ exports.mq4HoverShim = {
             "@media (orientation: landscape) { PREFIX>.foobar { display: none; } }"
         );
         test.deepEqual(
-            postprocessor({hoverSelectorPrefix: 'PREFIX>'}).process("@media screen (orientation: landscape) { @media (hover: hover) { .foobar { display: none; } } }").css,
-            "@media screen (orientation: landscape) { PREFIX>.foobar { display: none; } }"
+            postprocessor({hoverSelectorPrefix: 'PREFIX>'}).process("@media screen and (orientation: landscape) { @media (hover: hover) { .foobar { display: none; } } }").css,
+            "@media screen and (orientation: landscape) { PREFIX>.foobar { display: none; } }"
         );
         test.deepEqual(
             postprocessor({hoverSelectorPrefix: 'PREFIX>'}).process("@media (hover: hover) { @media (orientation: landscape) { .foobar { display: none; } } }").css,
             "@media (orientation: landscape) {\n    PREFIX>.foobar {\n        display: none;\n    }\n}"
         );
         test.deepEqual(
-            postprocessor({hoverSelectorPrefix: 'PREFIX>'}).process("@media (hover: hover) { @media screen (orientation: landscape) { .foobar { display: none; } } }").css,
-            "@media screen (orientation: landscape) {\n    PREFIX>.foobar {\n        display: none;\n    }\n}"
+            postprocessor({hoverSelectorPrefix: 'PREFIX>'}).process("@media (hover: hover) { @media screen and (orientation: landscape) { .foobar { display: none; } } }").css,
+            "@media screen and (orientation: landscape) {\n    PREFIX>.foobar {\n        display: none;\n    }\n}"
         );
         test.done();
     },
     'handles applicable media types': function (test) {
         test.expect(1);
         test.deepEqual(
-            postprocessor({hoverSelectorPrefix: 'PREFIX>'}).process("@media screen (hover: hover) { .foobar { display: none; } }").css,
+            postprocessor({hoverSelectorPrefix: 'PREFIX>'}).process("@media screen and (hover: hover) { .foobar { display: none; } }").css,
             "@media screen { PREFIX>.foobar { display: none; } }"
         );
         test.done();
@@ -132,7 +132,7 @@ exports.mq4HoverShim = {
     'handles non-applicable media types': function (test) {
         test.expect(1);
         test.deepEqual(
-            postprocessor({hoverSelectorPrefix: 'PREFIX>'}).process("@media print (hover: hover) { .foobar { display: none; } }").css,
+            postprocessor({hoverSelectorPrefix: 'PREFIX>'}).process("@media print and (hover: hover) { .foobar { display: none; } }").css,
             ""
         );
         test.done();


### PR DESCRIPTION
Need to tolerate CSS media query browser hacks for Bootstrap v4.