### PR TITLE
Remove the jQuery dependency for triggering event

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "grunt": "^0.4.5",
     "grunt-babel": "^5.0.0",
     "grunt-browserify": "^4.0.0",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-contrib-nodeunit": "^0.4.1",
     "grunt-eslint": "^17.2.0",


### PR DESCRIPTION
The custom event mq4hsChange can be triggered without jQuery. Added support for jQuery to include the custom props in the jQuery Event object.
